### PR TITLE
feat/Naver map search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@
 
 https://nightly.link/JellyBrick/korea-covid-19-remaining-vaccine/workflows/gradle/main/Covid-remaining-8.zip
 
-### 실험적 / 선택한 백신만 예약 시도하는 버전 다운로드
-
-https://github.com/JellyBrick/korea-covid-19-remaining-vaccine/suites/3444626118/artifacts/81699164
-
 
 ## 포함되어있는 라이브러리
 

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/App.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/App.kt
@@ -278,7 +278,11 @@ class App {
                 .third
 
             fuelError?.let {
-                close(throwable = it.exception)
+                if (it.response.statusCode == 500) {
+                    log.warn("백신 검색 서버 내부에서 오류 발생 (HTTP CODE 500). 재시도합니다.")
+                } else {
+                    close(throwable = it.exception)
+                }
             }
 
             response?.let { result ->

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/App.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/App.kt
@@ -286,7 +286,7 @@ class App {
             }
 
             response?.let { result ->
-                result.first().data.rests.businesses.items.forEach topLevelForEach@{
+                result.first().data.rests?.businesses?.items?.forEach topLevelForEach@{
                     if (it.vaccineQuantity.totalQuantity > 0) {
                         log.info("${it.name}에서 백신을 ${it.vaccineQuantity.totalQuantity}개 발견했습니다.")
                         log.info("주소는 ${it.roadAddress}입니다.")

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/App.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/App.kt
@@ -212,8 +212,10 @@ class App {
 
     private fun findVaccine() {
         while (true) {
-            val centerX = min(config.top.x, config.bottom.x) + (max(config.top.x, config.bottom.x) - min(config.top.x, config.bottom.x) / 2)
-            val centerY = min(config.top.y, config.bottom.y) + (max(config.top.y, config.bottom.y) - min(config.top.y, config.bottom.y) / 2)
+            val centerX = min(config.top.x, config.bottom.x) +
+                (max(config.top.x, config.bottom.x) - min(config.top.x, config.bottom.x) / 2)
+            val centerY = min(config.top.y, config.bottom.y) +
+                (max(config.top.y, config.bottom.y) - min(config.top.y, config.bottom.y) / 2)
             ignoreSsl()
             val (response, fuelError) = fuelManager
                 .post("https://api.place.naver.com/graphql")
@@ -242,11 +244,29 @@ class App {
                                             x = centerX.toString(),
                                             y = centerY.toString(),
                                             sortingOrder = "distance"
-                                        ),
-                                        isNmap = false,
-                                        isBounds = false
+                                        )
                                     ),
-                                    query = "query vaccineList(\$input: RestsInput, \$businessesInput: RestsBusinessesInput, \$isNmap: Boolean!, \$isBounds: Boolean!) {\n  rests(input: \$input) {\n    businesses(input: \$businessesInput) {\n      total\n      vaccineLastSave\n      isUpdateDelayed\n      items {\n        id\n        name\n        dbType\n        phone\n        virtualPhone\n        hasBooking\n        hasNPay\n        bookingReviewCount\n        description\n        distance\n        commonAddress\n        roadAddress\n        address\n        imageUrl\n        imageCount\n        tags\n        distance\n        promotionTitle\n        category\n        routeUrl\n        businessHours\n        x\n        y\n        imageMarker @include(if: \$isNmap) {\n          marker\n          markerSelected\n          __typename\n        }\n        markerLabel @include(if: \$isNmap) {\n          text\n          style\n          __typename\n        }\n        isDelivery\n        isTakeOut\n        isPreOrder\n        isTableOrder\n        naverBookingCategory\n        bookingDisplayName\n        bookingBusinessId\n        bookingVisitId\n        bookingPickupId\n        vaccineOpeningHour {\n          isDayOff\n          standardTime\n          __typename\n        }\n        vaccineQuantity {\n          totalQuantity\n          totalQuantityStatus\n          startTime\n          endTime\n          vaccineOrganizationCode\n          list {\n            quantity\n            quantityStatus\n            vaccineType\n            __typename\n          }\n          __typename\n        }\n        __typename\n      }\n      optionsForMap @include(if: \$isBounds) {\n        maxZoom\n        minZoom\n        includeMyLocation\n        maxIncludePoiCount\n        center\n        __typename\n      }\n      __typename\n    }\n    queryResult {\n      keyword\n      vaccineFilter\n      categories\n      region\n      isBrandList\n      filterBooking\n      hasNearQuery\n      isPublicMask\n      __typename\n    }\n    __typename\n  }\n}\n"
+                                    query = "query vaccineList(\$input: RestsInput, \$businessesInput: RestsBusinessesInput) {\n" +
+                                        "  rests(input: \$input) {\n" +
+                                        "    businesses(input: \$businessesInput) {\n" +
+                                        "      items {\n" +
+                                        "        id\n" +
+                                        "        name\n" +
+                                        "        roadAddress\n" +
+                                        "        vaccineQuantity {\n" +
+                                        "          totalQuantity\n" +
+                                        "          totalQuantityStatus\n" +
+                                        "          vaccineOrganizationCode\n" +
+                                        "          list {\n" +
+                                        "            quantity\n" +
+                                        "            quantityStatus\n" +
+                                        "            vaccineType\n" +
+                                        "            __typename\n" +
+                                        "          }\n" +
+                                        "          __typename\n" +
+                                        "        }\n" +
+                                        "      }" +
+                                        "}}}"
                                 )
                             )
                         }

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/App.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/App.kt
@@ -285,7 +285,7 @@ class App {
                         }
 
                         if (vaccineFoundCode === null) {
-                            log.error("$vaccineFoundCode 백신이 없습니다.")
+                            log.error("백신이 없습니다.")
                             return@topLevelForEach
                         }
 

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/App.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/App.kt
@@ -246,13 +246,13 @@ class App {
                                         isNmap = false,
                                         isBounds = false
                                     ),
-                                    query = "query vaccineList(\$input: RestsInput, \$businessesInput: RestsBusinessesInput, \$isNmap: Boolean!, \$isBounds: Boolean!) {\\n  rests(input: \$input) {\\n    businesses(input: \$businessesInput) {\\n      total\\n      vaccineLastSave\\n      isUpdateDelayed\\n      items {\\n        id\\n        name\\n        dbType\\n        phone\\n        virtualPhone\\n        hasBooking\\n        hasNPay\\n        bookingReviewCount\\n        description\\n        distance\\n        commonAddress\\n        roadAddress\\n        address\\n        imageUrl\\n        imageCount\\n        tags\\n        distance\\n        promotionTitle\\n        category\\n        routeUrl\\n        businessHours\\n        x\\n        y\\n        imageMarker @include(if: \$isNmap) {\\n          marker\\n          markerSelected\\n          __typename\\n        }\\n        markerLabel @include(if: \$isNmap) {\\n          text\\n          style\\n          __typename\\n        }\\n        isDelivery\\n        isTakeOut\\n        isPreOrder\\n        isTableOrder\\n        naverBookingCategory\\n        bookingDisplayName\\n        bookingBusinessId\\n        bookingVisitId\\n        bookingPickupId\\n        vaccineOpeningHour {\\n          isDayOff\\n          standardTime\\n          __typename\\n        }\\n        vaccineQuantity {\\n          totalQuantity\\n          totalQuantityStatus\\n          startTime\\n          endTime\\n          vaccineOrganizationCode\\n          list {\\n            quantity\\n            quantityStatus\\n            vaccineType\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      optionsForMap @include(if: \$isBounds) {\\n        maxZoom\\n        minZoom\\n        includeMyLocation\\n        maxIncludePoiCount\\n        center\\n        __typename\\n      }\\n      __typename\\n    }\\n    queryResult {\\n      keyword\\n      vaccineFilter\\n      categories\\n      region\\n      isBrandList\\n      filterBooking\\n      hasNearQuery\\n      isPublicMask\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n"
+                                    query = "query vaccineList(\$input: RestsInput, \$businessesInput: RestsBusinessesInput, \$isNmap: Boolean!, \$isBounds: Boolean!) {\n  rests(input: \$input) {\n    businesses(input: \$businessesInput) {\n      total\n      vaccineLastSave\n      isUpdateDelayed\n      items {\n        id\n        name\n        dbType\n        phone\n        virtualPhone\n        hasBooking\n        hasNPay\n        bookingReviewCount\n        description\n        distance\n        commonAddress\n        roadAddress\n        address\n        imageUrl\n        imageCount\n        tags\n        distance\n        promotionTitle\n        category\n        routeUrl\n        businessHours\n        x\n        y\n        imageMarker @include(if: \$isNmap) {\n          marker\n          markerSelected\n          __typename\n        }\n        markerLabel @include(if: \$isNmap) {\n          text\n          style\n          __typename\n        }\n        isDelivery\n        isTakeOut\n        isPreOrder\n        isTableOrder\n        naverBookingCategory\n        bookingDisplayName\n        bookingBusinessId\n        bookingVisitId\n        bookingPickupId\n        vaccineOpeningHour {\n          isDayOff\n          standardTime\n          __typename\n        }\n        vaccineQuantity {\n          totalQuantity\n          totalQuantityStatus\n          startTime\n          endTime\n          vaccineOrganizationCode\n          list {\n            quantity\n            quantityStatus\n            vaccineType\n            __typename\n          }\n          __typename\n        }\n        __typename\n      }\n      optionsForMap @include(if: \$isBounds) {\n        maxZoom\n        minZoom\n        includeMyLocation\n        maxIncludePoiCount\n        center\n        __typename\n      }\n      __typename\n    }\n    queryResult {\n      keyword\n      vaccineFilter\n      categories\n      region\n      isBrandList\n      filterBooking\n      hasNearQuery\n      isPublicMask\n      __typename\n    }\n    __typename\n  }\n}\n"
                                 )
                             )
                         }
                     )
                 )
-                .header(NORMAL_HEADERS)
+                .header(NAVER_HEADERS)
                 .timeout(5000)
                 .responseObject<List<VaccineSearchResult>>(mapper = mapper)
                 .third
@@ -262,7 +262,7 @@ class App {
             }
 
             response?.let { result ->
-                result.first().data.businesses.items.forEach topLevelForEach@{
+                result.first().data.rests.businesses.items.forEach topLevelForEach@{
                     if (it.vaccineQuantity.totalQuantity > 0) {
                         log.info("${it.name}에서 백신을 ${it.vaccineQuantity.totalQuantity}개 발견했습니다.")
                         log.info("주소는 ${it.roadAddress}입니다.")
@@ -286,6 +286,7 @@ class App {
                                     break
                                 }
                             }
+                            return@topLevelForEach
                         }
 
                         log.info("$vaccineFoundCode 백신으로 예약을 시도합니다.")
@@ -505,6 +506,14 @@ class App {
             "Accept-Language" to "en-us",
             "User-Agent" to "Mozilla/5.0 (iPhone; CPU iPhone OS 14_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 KAKAOTALK 9.4.2",
             "Referer" to "https://vaccine-map.kakao.com/"
+        )
+
+        val NAVER_HEADERS = mapOf(
+            "Accept" to "application/json, text/plain, */*",
+            "Content-Type" to "application/json;charset=utf-8",
+            "Origin" to "https://m.place.naver.com",
+            "User-Agent" to "Mozilla/5.0 (iPhone; CPU iPhone OS 14_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 KAKAOTALK 9.4.2",
+            "Referer" to "https://m.place.naver.com/rest/vaccine?vaccineFilter=used"
         )
 
         val VACCINE_HEADER = mapOf(

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/App.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/App.kt
@@ -275,10 +275,6 @@ class App {
                                     // 될 수 있는 경우 AZ 대신 화이자 / 모더나 선택
                                 }
                             }
-                            if (vaccineFoundCode === null) {
-                                log.error("백신이 없습니다.")
-                                return@topLevelForEach
-                            }
                         } else {
                             for (vaccineInfo in it.vaccineQuantity.list) {
                                 if (KAKAO_TO_NAVER_MAP[config.vaccineType] == vaccineInfo.vaccineType && vaccineInfo.quantity > 0) {
@@ -286,6 +282,10 @@ class App {
                                     break
                                 }
                             }
+                        }
+
+                        if (vaccineFoundCode === null) {
+                            log.error("$vaccineFoundCode 백신이 없습니다.")
                             return@topLevelForEach
                         }
 

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/kakao/FindVaccineResult.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/kakao/FindVaccineResult.kt
@@ -1,4 +1,4 @@
-package be.zvz.covid.remaining.vaccine.dto.reservation
+package be.zvz.covid.remaining.vaccine.dto.reservation.kakao
 
 data class FindVaccineResult(
     val organizations: List<Organization>

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/kakao/Organization.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/kakao/Organization.kt
@@ -1,4 +1,4 @@
-package be.zvz.covid.remaining.vaccine.dto.reservation
+package be.zvz.covid.remaining.vaccine.dto.reservation.kakao
 
 data class Organization(
     val status: String,

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/kakao/OrganizationInfo.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/kakao/OrganizationInfo.kt
@@ -1,4 +1,4 @@
-package be.zvz.covid.remaining.vaccine.dto.reservation
+package be.zvz.covid.remaining.vaccine.dto.reservation.kakao
 
 data class OrganizationInfo(
     val leftCount: Int,

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/kakao/OrganizationInfos.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/kakao/OrganizationInfos.kt
@@ -1,4 +1,4 @@
-package be.zvz.covid.remaining.vaccine.dto.reservation
+package be.zvz.covid.remaining.vaccine.dto.reservation.kakao
 
 data class OrganizationInfos(
     val lefts: List<OrganizationInfo>

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/kakao/ReservationOrganization.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/kakao/ReservationOrganization.kt
@@ -1,4 +1,4 @@
-package be.zvz.covid.remaining.vaccine.dto.reservation
+package be.zvz.covid.remaining.vaccine.dto.reservation.kakao
 
 data class ReservationOrganization(
     val orgName: String,

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/kakao/ReservationResult.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/kakao/ReservationResult.kt
@@ -1,4 +1,4 @@
-package be.zvz.covid.remaining.vaccine.dto.reservation
+package be.zvz.covid.remaining.vaccine.dto.reservation.kakao
 
 data class ReservationResult(
     val code: String,

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/naver/MapSearchInput.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/naver/MapSearchInput.kt
@@ -1,0 +1,29 @@
+package be.zvz.covid.remaining.vaccine.dto.reservation.naver
+
+data class MapSearchInput(
+    val operationName: String,
+    val variables: Variables,
+    val query: String
+) {
+    data class Variables(
+        val input: Input,
+        val businessesInput: BusinessesInput,
+        val isNmap: Boolean,
+        val isBounds: Boolean
+    ) {
+        data class Input(
+            val keyword: String,
+            val x: String,
+            val y: String
+        )
+        data class BusinessesInput(
+            val bounds: String,
+            val start: Int,
+            val display: Int,
+            val deviceType: String,
+            val x: String,
+            val y: String,
+            val sortingOrder: String
+        )
+    }
+}

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/naver/MapSearchInput.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/naver/MapSearchInput.kt
@@ -7,9 +7,7 @@ data class MapSearchInput(
 ) {
     data class Variables(
         val input: Input,
-        val businessesInput: BusinessesInput,
-        val isNmap: Boolean,
-        val isBounds: Boolean
+        val businessesInput: BusinessesInput
     ) {
         data class Input(
             val keyword: String,

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/naver/VaccineSearchResult.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/naver/VaccineSearchResult.kt
@@ -10,7 +10,6 @@ data class VaccineSearchResult(
             val businesses: Businesses
         ) {
             data class Businesses(
-                val total: Int,
                 val items: List<Business>,
             ) {
                 data class Business(

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/naver/VaccineSearchResult.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/naver/VaccineSearchResult.kt
@@ -4,7 +4,7 @@ data class VaccineSearchResult(
     val data: Data
 ) {
     data class Data(
-        val rests: Rests
+        val rests: Rests?
     ) {
         data class Rests(
             val businesses: Businesses

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/naver/VaccineSearchResult.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/naver/VaccineSearchResult.kt
@@ -1,33 +1,36 @@
 package be.zvz.covid.remaining.vaccine.dto.reservation.naver
 
 data class VaccineSearchResult(
-    val data: Rests
+    val data: Data
 ) {
-    data class Rests(
-        val businesses: Businesses
+    data class Data(
+        val rests: Rests
     ) {
-        data class Businesses(
-            val total: Int,
-            val items: List<Business>,
+        data class Rests(
+            val businesses: Businesses
         ) {
-            data class Business(
-                val id: String,
-                val name: String,
-                val phone: String,
-                val roadAddress: String,
-                val vaccineQuantity: VaccineQuantity
+            data class Businesses(
+                val total: Int,
+                val items: List<Business>,
             ) {
-                data class VaccineQuantity(
-                    val totalQuantity: Int,
-                    val totalQuantityStatus: String,
-                    val vaccineOrganizationCode: String,
-                    val list: List<VaccineInfo>
+                data class Business(
+                    val id: String,
+                    val name: String,
+                    val roadAddress: String,
+                    val vaccineQuantity: VaccineQuantity
                 ) {
-                    data class VaccineInfo(
-                        val quantity: Int,
-                        val quantityStatus: String,
-                        val vaccineType: String
-                    )
+                    data class VaccineQuantity(
+                        val totalQuantity: Int,
+                        val totalQuantityStatus: String,
+                        val vaccineOrganizationCode: String,
+                        val list: List<VaccineInfo>
+                    ) {
+                        data class VaccineInfo(
+                            val quantity: Int,
+                            val quantityStatus: String,
+                            val vaccineType: String
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/naver/VaccineSearchResult.kt
+++ b/app/src/main/kotlin/be/zvz/covid/remaining/vaccine/dto/reservation/naver/VaccineSearchResult.kt
@@ -1,0 +1,35 @@
+package be.zvz.covid.remaining.vaccine.dto.reservation.naver
+
+data class VaccineSearchResult(
+    val data: Rests
+) {
+    data class Rests(
+        val businesses: Businesses
+    ) {
+        data class Businesses(
+            val total: Int,
+            val items: List<Business>,
+        ) {
+            data class Business(
+                val id: String,
+                val name: String,
+                val phone: String,
+                val roadAddress: String,
+                val vaccineQuantity: VaccineQuantity
+            ) {
+                data class VaccineQuantity(
+                    val totalQuantity: Int,
+                    val totalQuantityStatus: String,
+                    val vaccineOrganizationCode: String,
+                    val list: List<VaccineInfo>
+                ) {
+                    data class VaccineInfo(
+                        val quantity: Int,
+                        val quantityStatus: String,
+                        val vaccineType: String
+                    )
+                }
+            }
+        }
+    }
+}

--- a/detekt.yml
+++ b/detekt.yml
@@ -267,7 +267,7 @@ formatting:
     continuationIndentSize: 4
   MaximumLineLength:
     active: true
-    maxLineLength: 130
+    maxLineLength: 180
     ignoreBackTickedIdentifier: false
   ModifierOrdering:
     active: true
@@ -614,7 +614,7 @@ style:
     active: false
   MaxLineLength:
     active: true
-    maxLineLength: 130
+    maxLineLength: 180
     excludePackageStatements: true
     excludeImportStatements: true
     excludeCommentStatements: false


### PR DESCRIPTION
# PR 요약

- 잔여백신 검색시 카카오 API 대신 네이버 API 사용하게 변경
- 예약은 카카오 API로 진행

# 개선점

## `ANY`일 경우 

- AZ와 화이자/모더나/얀센이 같이 있을 경우 AZ 대신 다른 백신이 선택됨
- 그 외: 동작 같음

## 백신을 선택해놓은 경우

- 해당하는 백신이 없는 경우 예약 요청을 보내지 않음